### PR TITLE
🚀 Update to version 1.0.0-a.13

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -35,12 +35,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.11/zen.linux-generic.tar.bz2
-        sha256: 3b5010e63b478dd7fc9693d612beb99f54170524c85f9b2d4524e06ed4ac543a
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.13/zen.linux-generic.tar.bz2
+        sha256: ce4686b1df797af2e841d035c76a0f9cfd9971c242a8bdd381617423ae5e5cbc
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.11/archive.tar
+        url: https://github.com/zen-browser/flatpak/releases/latest/download/archive.tar
         sha256: 0c7f283fa68066814eba40da9698166161a6e4aa586d22eb3e016bd822f23604
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.13. 

@mauro-balades