### PR TITLE
🚀 Update to version 1.0.0-a.18

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -35,8 +35,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.17/zen.linux-generic.tar.bz2
-        sha256: 499dd7e8b85d7d9ce1a90db97a284f29fdf7ca3a77d9a4bd17534c4ee74cabf6
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.18/zen.linux-generic.tar.bz2
+        sha256: 3f1e89a14303a383b98c6b22fdbd57958b7dea711d0775165b443b414aca3acd
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.18. 

@mauro-balades