### PR TITLE
🚀 Update to version 1.0.0-a.20

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -35,8 +35,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.19/zen.linux-generic.tar.bz2
-        sha256: d38eb8c378a2483e0bc6e54f2a6b0a843db459e3d0690857279f818a0e72c575
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.20/zen.linux-generic.tar.bz2
+        sha256: 41a070dc6c9e7589ab06722a745fdffa65f84c22bf97a8148deee6d667f850a7
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.20. 

@mauro-balades