### PR TITLE
🚀 Update to version 1.0.0-a.26

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -35,8 +35,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.24/zen.linux-generic.tar.bz2
-        sha256: 3cbd510492131b6187999ee2b8de391016c2a78376f723dfc230f5415068057e
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.26/zen.linux-generic.tar.bz2
+        sha256: 98aba66c3a3b3d11badbcba50315f81cc8725a4997848d9165929c528fdb1eb6
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.26. 

@mauro-balades