### PR TITLE
🚀 Update to version 1.0.0-a.28

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -35,8 +35,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.27/zen.linux-generic.tar.bz2
-        sha256: c5a24059ee9f4c8165128b5a03038f0880529c661e0d5ace44add3a1d24b284c
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.28/zen.linux-generic.tar.bz2
+        sha256: 34d63f8fb197ff9a8d9766e9a5ef8c486aaafad605d6a6790933697dbcb12983
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.28. 

@mauro-balades