### PR TITLE
🚀 Update to version 1.0.0-a.31

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -36,8 +36,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.30/zen.linux-generic.tar.bz2
-        sha256: 54359749a9503d714fe2f884005fead3ffd7e1a29cd0948c643a78a3f985047b
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.31/zen.linux-generic.tar.bz2
+        sha256: 5d813211039d237c03098c2acb5dec08464cc3c56e059561bd12eb0a1e428eae
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.31. 

@mauro-balades