### PR TITLE
🚀 Update to version 1.0.0-a.32

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -36,8 +36,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.30/zen.linux-generic.tar.bz2
-        sha256: 54359749a9503d714fe2f884005fead3ffd7e1a29cd0948c643a78a3f985047b
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.32/zen.linux-generic.tar.bz2
+        sha256: a66dfd28cca84e8b3071eab5334f5479a5b7bd805811e703422530e9bb4b3210
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.32. 

@mauro-balades