### PR TITLE
🚀 Update to version 1.0.0-a.34

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -36,8 +36,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.33/zen.linux-generic.tar.bz2
-        sha256: 2810325119e20763df526c00a8d5769be2cadf050a33336b3cf3f25491818610
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.34/zen.linux-generic.tar.bz2
+        sha256: 0599589ba206e62534cfdd532670f080332141051de69f860031ea3f567f1b07
         strip-components: 0
 
       - type: archive


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.34. 

@mauro-balades