### PR TITLE
🚀 Update to version 1.0.0-a.37

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -42,6 +42,6 @@ modules:
 
       - type: archive
         url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.37/archive.tar
-        sha256: 786648372e5e16cc4a451518b4360e87696e5a736a085a1bb3edd5899e6f13ce
+        sha256: bdfe15a619e8c7a4c6d8cb1f2bedb3495e69357ee66fced0a21af628d13841cf
         strip-components: 0
         dest: metadata

--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -42,6 +42,6 @@ modules:
 
       - type: archive
         url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.37/archive.tar
-        sha256: 12d8b76fae1cc65e90121752ff53cded6dafee5572a762e8dfdea8b60e5d85d8
+        sha256: 0f25fcd8a0664c01c2dbfe0e07ae5f5ec0c52abc7827dbcb200180638a21a9c6
         strip-components: 0
         dest: metadata

--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -36,12 +36,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.33/zen.linux-generic.tar.bz2
-        sha256: 2810325119e20763df526c00a8d5769be2cadf050a33336b3cf3f25491818610
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.37/zen.linux-generic.tar.bz2
+        sha256: 6b1d99a26299b16cce4210d4f7f62a0ecc4bfc81295131d7fcdfa8aac9a18988
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/latest/download/archive.tar
-        sha256: c641b4861b5c505ac78c75ac1f00d0771f03e2f2716583525c17dead1d0b8f6c
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.37/archive.tar
+        sha256: 786648372e5e16cc4a451518b4360e87696e5a736a085a1bb3edd5899e6f13ce
         strip-components: 0
         dest: metadata

--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -42,6 +42,6 @@ modules:
 
       - type: archive
         url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.37/archive.tar
-        sha256: bdfe15a619e8c7a4c6d8cb1f2bedb3495e69357ee66fced0a21af628d13841cf
+        sha256: 12d8b76fae1cc65e90121752ff53cded6dafee5572a762e8dfdea8b60e5d85d8
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.0-a.37. 

@mauro-balades please review and merge this PR.