### PR TITLE
🚀 Update to version 1.0.1-a

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.0-a.39/zen.linux-generic.tar.bz2
-        sha256: 9dddbca7c934a11b058d6f9f6a65dd32646be903e8b810c7c75e58d2aabe721f
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a/zen.linux-generic.tar.bz2
+        sha256: 844400da1f190f72c651958ad44a8ec154dd2f95275037e17d8401acab6c5275
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.0-a.39/archive.tar
-        sha256: d9fae8b793d82565d4b7e84ccae9fc0dbd9d67a6d1d4869f35301bed2c0fde50
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a/archive.tar
+        sha256: 43be217700a3d8cb1fa6fe9e754b0f821e5845f59c0a51ad22b2218941ed41d9
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.

@mauro-balades please review and merge this PR.