### PR TITLE
🚀 Update to version 1.0.1-a.1

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a/zen.linux-generic.tar.bz2
-        sha256: 844400da1f190f72c651958ad44a8ec154dd2f95275037e17d8401acab6c5275
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.1/zen.linux-generic.tar.bz2
+        sha256: 21d99d76b122e59323e5e2494690da07b36a853442eb57b0123aee9ed7104b23
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a/archive.tar
-        sha256: 43be217700a3d8cb1fa6fe9e754b0f821e5845f59c0a51ad22b2218941ed41d9
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.1/archive.tar
+        sha256: 2ad26a48e3a146e1132d9a37ee61cc58b408e1ee50bb93e84fcdd84e0d9501e8
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.1.

@mauro-balades please review and merge this PR.