### PR TITLE
🚀 Update to version 1.0.1-a.2

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.1/zen.linux-generic.tar.bz2
-        sha256: 21d99d76b122e59323e5e2494690da07b36a853442eb57b0123aee9ed7104b23
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.2/zen.linux-generic.tar.bz2
+        sha256: 9cbcddeea37876ece4095a94804ebd6166c63cb86f897d4015fa3d2b92bb6818
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.1/archive.tar
-        sha256: 2ad26a48e3a146e1132d9a37ee61cc58b408e1ee50bb93e84fcdd84e0d9501e8
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.2/archive.tar
+        sha256: d6499b31ffc51b17f45dcecc03910b885fe7e33e91a90455b1cd214d88eaa4c5
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.2.

@mauro-balades please review and merge this PR.