### PR TITLE
🚀 Update to version 1.0.1-a.3

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.2/zen.linux-generic.tar.bz2
-        sha256: 9cbcddeea37876ece4095a94804ebd6166c63cb86f897d4015fa3d2b92bb6818
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.3/zen.linux-generic.tar.bz2
+        sha256: 1c6006f0e796779babeeb121a02b1169c5b558e4b68de4ac1cd1e116d21f47ff
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.2/archive.tar
-        sha256: d6499b31ffc51b17f45dcecc03910b885fe7e33e91a90455b1cd214d88eaa4c5
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.3/archive.tar
+        sha256: 5dc49f7b3d98bf58a3e0240cde917b66cef10bba33bf5294a2794aba44f9d1ff
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.3.

@mauro-balades please review and merge this PR.