### PR TITLE
🚀 Update to version 1.0.1-a.4

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.3/zen.linux-generic.tar.bz2
-        sha256: 1c6006f0e796779babeeb121a02b1169c5b558e4b68de4ac1cd1e116d21f47ff
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.4/zen.linux-generic.tar.bz2
+        sha256: 788c1d743b16e88a10226e1b2c0d440fee9061ec52eea2323b7434f5018205b5
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.3/archive.tar
-        sha256: 5dc49f7b3d98bf58a3e0240cde917b66cef10bba33bf5294a2794aba44f9d1ff
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.4/archive.tar
+        sha256: b874f6b49fd8e7e58a6a28ec162c7056c27ae24aa72e5211478748add0f4e7b5
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.4.

@mauro-balades please review and merge this PR.