### PR TITLE
🚀 Update to version 1.0.1-a.5

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.4/zen.linux-generic.tar.bz2
-        sha256: 788c1d743b16e88a10226e1b2c0d440fee9061ec52eea2323b7434f5018205b5
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.5/zen.linux-generic.tar.bz2
+        sha256: 8b490ff5b55685abcac698d3267a7cdbb327db125086df13fa9482f0c67ed532
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.4/archive.tar
-        sha256: b874f6b49fd8e7e58a6a28ec162c7056c27ae24aa72e5211478748add0f4e7b5
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.5/archive.tar
+        sha256: a1d9bc9dbdffea52bbde68a4adcf7e2b49a809e304be8db47af8947b62c28c65
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.5.

@mauro-balades please review and merge this PR.