### PR TITLE
🚀 Update to version 1.0.1-a.6

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.5/zen.linux-generic.tar.bz2
-        sha256: 8b490ff5b55685abcac698d3267a7cdbb327db125086df13fa9482f0c67ed532
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.6/zen.linux-generic.tar.bz2
+        sha256: fa4a624734e2df3a50560d2deb709547f4a1febe84b85b4e1397057d0ee74bf0
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.5/archive.tar
-        sha256: a1d9bc9dbdffea52bbde68a4adcf7e2b49a809e304be8db47af8947b62c28c65
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.6/archive.tar
+        sha256: 3ee31f32de02e13a632b9df85f130a689838259c4c74f8df418bd8860de6c576
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.6.

@mauro-balades please review and merge this PR.