### PR TITLE
🚀 Update to version 1.0.1-a.8

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.7/zen.linux-generic.tar.bz2
-        sha256: f0b86668a4715ef93a8c1bcf0831aa0f791221b0f235db071feba413cfce57fb
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.8/zen.linux-generic.tar.bz2
+        sha256: 1e8fa61fca7e3b02a38b7b21954163680838db7faae50520875946fbbf3f928d
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.7/archive.tar
-        sha256: 05609c4af14c5f22b33e6cac99205e66c9f47e5876d305fe35ae42c9380f68ec
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.8/archive.tar
+        sha256: 33fb4112c37307bccf5c39b9e2710d38939c305484f58577b85b0eecf43a0fba
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.8.

@mauro-balades please review and merge this PR.