### PR TITLE
🚀 Update to version 1.0.1-a.9

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.8/zen.linux-generic.tar.bz2
-        sha256: 1e8fa61fca7e3b02a38b7b21954163680838db7faae50520875946fbbf3f928d
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.9/zen.linux-generic.tar.bz2
+        sha256: dc77c03ccad47d6e5553e07b4e83eeac8803cffc0d91ce14e52a33a8afac5dc3
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.8/archive.tar
-        sha256: 33fb4112c37307bccf5c39b9e2710d38939c305484f58577b85b0eecf43a0fba
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.9/archive.tar
+        sha256: 54229e4a4cd27e131715e2714e448feef898edbad923abfbb9ffd5732edab723
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.9.

@mauro-balades please review and merge this PR.