### PR TITLE
🚀 Update to version 1.0.1-a.11

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.10/zen.linux-generic.tar.bz2
-        sha256: 704bebea56dc88822d051d1da488b9347ebb854abe85bd9fcf04e42930ebafd1
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.11/zen.linux-generic.tar.bz2
+        sha256: 3d6e35bb2f73de6b30e584e2c3f6238689a48aa3da62de0e8abec429c921c2ac
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.10/archive.tar
-        sha256: 54ba2978fc10e0492df7732e788542c181ce1d46c3e948041c9ec5c72c163fc2
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.11/archive.tar
+        sha256: 82b2e4bb14adf5edf27169266d768f3aaed0b96484406e4c25ed527d89cf57f0
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.11.

@mauro-balades please review and merge this PR.