### PR TITLE
🚀 Update to version 1.0.1-a.12

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.11/zen.linux-generic.tar.bz2
-        sha256: 3d6e35bb2f73de6b30e584e2c3f6238689a48aa3da62de0e8abec429c921c2ac
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.12/zen.linux-generic.tar.bz2
+        sha256: 297a6297d957aa04025bc95d560f4a4a20c23c3d07e0420165ba90b9681ac62a
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.11/archive.tar
-        sha256: 82b2e4bb14adf5edf27169266d768f3aaed0b96484406e4c25ed527d89cf57f0
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.12/archive.tar
+        sha256: 876d41af60fb50fbe2eebed7f0584394939787013b416c50bf8371ed88ec3b7f
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.12.

@mauro-balades please review and merge this PR.