### PR TITLE
🚀 Update to version 1.0.1-a.14

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.13/zen.linux-generic.tar.bz2
-        sha256: 684966f72fe4152a322f34339c48afa8462b6d4e4a68603f56e6405ca16319cd
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.14/zen.linux-generic.tar.bz2
+        sha256: cdb07f9a7d1c63774f3e4a10526900926ec2bf963f07788c392174fbc2aa20a2
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.13/archive.tar
-        sha256: ab127d775786337af71d7ea1879dc75ac7b90d86e2f13809f43c9886609df98f
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.14/archive.tar
+        sha256: 0df3b0364f9b3e1a4b54d2df605ba19acbc5d6362f746a91dbf65ec43dbabbe9
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.14.

@mauro-balades please review and merge this PR.