### PR TITLE
🚀 Update to version 1.0.1-a.15

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.14/zen.linux-generic.tar.bz2
-        sha256: cdb07f9a7d1c63774f3e4a10526900926ec2bf963f07788c392174fbc2aa20a2
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.15/zen.linux-generic.tar.bz2
+        sha256: 0a9b0ff1e5518124c70f01c9e6cb1bc40c8b346fe19a01225820f623744927a9
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.14/archive.tar
-        sha256: 0df3b0364f9b3e1a4b54d2df605ba19acbc5d6362f746a91dbf65ec43dbabbe9
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.15/archive.tar
+        sha256: babbd82eeec2d7269cd8ac1ecacfaa48ba9b8d216096a0481b5f4f4fa82c9337
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.15.

@mauro-balades please review and merge this PR.