### PR TITLE
🚀 Update to version 1.0.1-a.16

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.15/zen.linux-generic.tar.bz2
-        sha256: 0a9b0ff1e5518124c70f01c9e6cb1bc40c8b346fe19a01225820f623744927a9
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.16/zen.linux-generic.tar.bz2
+        sha256: 93f9a61843aa9dc18e9adae6f2d44980470c90a2055f31ebf075ad1e74707fb8
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.15/archive.tar
-        sha256: babbd82eeec2d7269cd8ac1ecacfaa48ba9b8d216096a0481b5f4f4fa82c9337
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.16/archive.tar
+        sha256: 210940cbab5dfbc627ca088162d67379528e70029fdc2603b1c8190ba8f49d43
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.16.

@mauro-balades please review and merge this PR.