### PR TITLE
🚀 Update to version 1.0.1-a.17

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.16/zen.linux-generic.tar.bz2
-        sha256: 93f9a61843aa9dc18e9adae6f2d44980470c90a2055f31ebf075ad1e74707fb8
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.17/zen.linux-generic.tar.bz2
+        sha256: 997a5cb48d267f9f6ffb23de87f6ade2aa2d441a914c8ea116192c20c7f2c9fa
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.16/archive.tar
-        sha256: 210940cbab5dfbc627ca088162d67379528e70029fdc2603b1c8190ba8f49d43
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.17/archive.tar
+        sha256: 226562c1cf07f7b6d5368ea5cc62077a462c86ef7dfbee5098e7b04ba7bd1410
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.17.

@mauro-balades please review and merge this PR.