### PR TITLE
🚀 Update to version 1.0.1-a.18

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -43,12 +43,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.17/zen.linux-generic.tar.bz2
-        sha256: 997a5cb48d267f9f6ffb23de87f6ade2aa2d441a914c8ea116192c20c7f2c9fa
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.1-a.18/zen.linux-generic.tar.bz2
+        sha256: cb86a817b403ff2d1947d2996c5f11b11db711f56145bddbb40041846f5b991e
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.17/archive.tar
-        sha256: 226562c1cf07f7b6d5368ea5cc62077a462c86ef7dfbee5098e7b04ba7bd1410
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.1-a.18/archive.tar
+        sha256: f71a6bf925da71847ea78206a2101e9dbf462665fdee59543b4211e7d4c9adbf
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.18.

@mauro-balades please review and merge this PR.