### PR TITLE
🚀 Update to version 1.0.1-a.22

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -22,7 +22,6 @@ finish-args:
   - --filesystem=xdg-download:rw
   - --device=all
   - --talk-name=org.freedesktop.FileManager1
-  - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mozilla.zen.*
   - --own-name=org.mpris.MediaPlayer2.firefox.*


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.1-a.22.

@mr-cheff please review and merge this PR.