### PR TITLE
🚀 Update to version 1.0.2-b.3

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -44,12 +44,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.2-b.2/zen.linux-generic.tar.bz2
-        sha256: 874c06543a720248bae04a43d64c66050bdf24cb3ded84a2b60cc22245d4965f
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.2-b.3/zen.linux-generic.tar.bz2
+        sha256: 41176423496e52f92dc5ab9fb98a0e370b1842552d1f83522bfa1bf73a14897f
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.2-b.2/archive.tar
-        sha256: 9d740c1738447ae940d7cab8b919557f8c830d05a0054370c4ecbed38750e64b
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.2-b.3/archive.tar
+        sha256: a8ce3856be835b3cd6e75f75d45a65b71571f062781276a1bc24b8aee8f41c09
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.2-b.3.

@mr-cheff please review and merge this PR.