### PR TITLE
🚀 Update to version 1.0.2-b.5

### DIFF
--- a/io.github.zen_browser.zen.yml
+++ b/io.github.zen_browser.zen.yml
@@ -44,12 +44,12 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/zen-browser/desktop/releases/download/1.0.2-b.4/zen.linux-x86_64.tar.bz2
-        sha256: a357a0344be51b9f0c5302bd4217ef935d16db6fe4f97607883b6b8e0a1f5a3c
+        url: https://github.com/zen-browser/desktop/releases/download/1.0.2-b.5/zen.linux-x86_64.tar.bz2
+        sha256: 2b7cd308b76f83f55840db1f7a8870eb91a193c1408e13a5f215d4e9110ee3fb
         strip-components: 0
 
       - type: archive
-        url: https://github.com/zen-browser/flatpak/releases/download/1.0.2-b.4/archive.tar
-        sha256: 35a634a5a4ab683fde053e70a8d75902733baaadbac13a07c951de79f61822ea
+        url: https://github.com/zen-browser/flatpak/releases/download/1.0.2-b.5/archive.tar
+        sha256: cedea7dc0fd1695733b7d340423affd5ea16928649ab03bfe56c537112d4f8bb
         strip-components: 0
         dest: metadata


### PR DESCRIPTION
This PR updates the Zen Browser Flatpak package to version 1.0.2-b.5.

@mr-cheff please review and merge this PR.